### PR TITLE
Fix imports and publicness of types

### DIFF
--- a/src/chart.rs
+++ b/src/chart.rs
@@ -1,7 +1,10 @@
 use std::{cell::RefCell, rc::Rc};
 
-use crate::{info_bar::InfoBar, ChartData, ChartRenderer, YAxis};
 use serde::Deserialize;
+
+use crate::{
+    chart_data::ChartData, chart_renderer::ChartRenderer, info_bar::InfoBar, y_axis::YAxis
+};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct Candle {
@@ -36,10 +39,10 @@ impl Candle {
 }
 
 pub struct Chart {
-    pub renderer: ChartRenderer,
-    pub y_axis: YAxis,
-    pub chart_data: Rc<RefCell<ChartData>>,
-    pub info_bar: InfoBar,
+    pub(crate) renderer: ChartRenderer,
+    pub(crate) y_axis: YAxis,
+    pub(crate) chart_data: Rc<RefCell<ChartData>>,
+    pub(crate) info_bar: InfoBar,
 }
 
 impl Chart {

--- a/src/chart_data.rs
+++ b/src/chart_data.rs
@@ -1,5 +1,5 @@
 use crate::{
-    candle_set::CandleSet, chart::Candle, chart_renderer::ChartRenderer, info_bar::InfoBar, YAxis,
+    candle_set::CandleSet, chart::Candle, chart_renderer::ChartRenderer, info_bar::InfoBar, y_axis::YAxis,
 };
 use terminal_size::terminal_size;
 

--- a/src/chart_renderer.rs
+++ b/src/chart_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{y_axis::YAxis, Candle, CandleType, Chart};
+use crate::{Candle, Chart, chart::CandleType, y_axis::YAxis};
 use colored::*;
 
 pub struct ChartRenderer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,10 @@
 mod chart;
-use chart::*;
-
 mod chart_renderer;
-use chart_renderer::*;
-
 mod y_axis;
-use y_axis::*;
-
 mod chart_data;
-use chart_data::*;
-
 mod candle_set;
-
 mod info_bar;
 
 pub use chart::Candle;
 pub use chart::Chart;
+pub use chart::CandleType;


### PR DESCRIPTION
Generally it is bad practice to have public fields that contain private types. You should also import types directly. Also the `CandleType` type was not public.